### PR TITLE
spa names

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -307,6 +307,30 @@
     	</skillPrereq>
 	</ability>
 	
+	<edgeTrigger>
+		<lookupName>edge_when_heal_crit_fail</lookupName>
+		<displayName>Use Edge for doctor critical failure.</displayName>
+		<desc>Healing check critical failure will be rerolled with Edge.</desc>
+	</edgeTrigger>
+	
+	<edgeTrigger>
+		<lookupName>edge_when_repair_break_part</lookupName>
+		<displayName>Use Edge for tech breaking part.</displayName>
+		<desc>Failed repair check that breaks the part will be rerolled with Edge.</desc>
+	</edgeTrigger>
+	
+	<edgeTrigger>
+		<lookupName>edge_when_fail_refit_check</lookupName>
+		<displayName>Use Edge for refit failure.</displayName>
+		<desc>Failed refit check will be rerolled with Edge.</desc>
+	</edgeTrigger>
+	
+	<edgeTrigger>
+		<lookupName>edge_when_admin_acquire_fail</lookupName>
+		<displayName>Use Edge for acquisition failure.</displayName>
+		<desc>Failed acquisition check will be rerolled with edge.</desc>
+	</edgeTrigger>
+	
 </abilities>
 
 <!--  

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -147,6 +147,8 @@ public class PersonnelOptions extends PilotOptions {
         public String getDisplayableName() {
             if (null != SpecialAbility.getAbility(name)) {
                 return SpecialAbility.getAbility(name).getDisplayName();
+            } else if (null != SpecialAbility.getEdgeTrigger(name)) {
+                return SpecialAbility.getEdgeTrigger(name).getDisplayName();
             } else if (null != mmOptions.getOption(name)){
                 return mmOptions.getOption(name).getDisplayableName();
             } else {
@@ -158,6 +160,8 @@ public class PersonnelOptions extends PilotOptions {
         public String getDisplayableNameWithValue() {
             if (null != SpecialAbility.getAbility(name)) {
                 return SpecialAbility.getAbility(name).getDisplayName();
+            } else if (null != SpecialAbility.getEdgeTrigger(name)) {
+                return SpecialAbility.getEdgeTrigger(name).getDisplayName();
             } else if (null != mmOptions.getOption(name)){
                 return mmOptions.getOption(name).getDisplayableName();
             } else {
@@ -169,6 +173,8 @@ public class PersonnelOptions extends PilotOptions {
         public String getDescription() {
             if (null != SpecialAbility.getAbility(name)) {
                 return SpecialAbility.getAbility(name).getDescription();
+            } else if (null != SpecialAbility.getEdgeTrigger(name)) {
+                return SpecialAbility.getEdgeTrigger(name).getDescription();
             } else if (null != mmOptions.getOption(name)){
                 return mmOptions.getOption(name).getDescription();
             } else {

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -65,6 +65,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
 
     private static Hashtable<String, SpecialAbility> specialAbilities;
     private static Hashtable<String, SpecialAbility> defaultSpecialAbilities;
+    private static Hashtable<String, SpecialAbility> edgeTriggers;
 
     private String displayName;
     private String lookupName;
@@ -85,8 +86,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
     //these are abilities that should be removed if the person gets this ability
     //(typically this is a lower value ability on the same chain (e.g. Cluster Hitter removed when you get Cluster Master)
     private Vector<String> removeAbilities;
-
-
+    
     public SpecialAbility() {
         this("unknown");
     }
@@ -315,7 +315,11 @@ public class SpecialAbility implements MekHqXmlSerializable {
             }
         }
         
-        specialAbilities.put(retVal.lookupName, retVal);
+        if (wn.getNodeName().equalsIgnoreCase("edgetrigger")) {
+            edgeTriggers.put(retVal.lookupName, retVal);
+        } else {
+            specialAbilities.put(retVal.lookupName, retVal);
+        }
     }
 
     public static void generateSeparateInstanceFromXML(Node wn, Hashtable<String, SpecialAbility> spHash, PilotOptions options) {
@@ -379,7 +383,8 @@ public class SpecialAbility implements MekHqXmlSerializable {
 
     public static void initializeSPA() {
         final String METHOD_NAME = "initializeSPA()"; //$NON-NLS-1$
-        specialAbilities = new Hashtable<String, SpecialAbility>();
+        specialAbilities = new Hashtable<>();
+        edgeTriggers = new Hashtable<>();
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
@@ -421,7 +426,8 @@ public class SpecialAbility implements MekHqXmlSerializable {
                 // Okay, so what element is it?
                 String xn = wn.getNodeName();
 
-                if (xn.equalsIgnoreCase("ability")) {
+                if (xn.equalsIgnoreCase("ability")
+                        || xn.equalsIgnoreCase("edgeTrigger")) {
                     SpecialAbility.generateInstanceFromXML(wn, options, null);
                 }
             }
@@ -443,6 +449,14 @@ public class SpecialAbility implements MekHqXmlSerializable {
 
     public static Hashtable<String, SpecialAbility> getAllDefaultSpecialAbilities() {
         return defaultSpecialAbilities;
+    }
+    
+    public static SpecialAbility getEdgeTrigger(String name) {
+        return edgeTriggers.get(name);
+    }
+
+    public static Hashtable<String, SpecialAbility> getAllEdgeTriggers() {
+        return edgeTriggers;
     }
 
     public static void replaceSpecialAbilities(Hashtable<String, SpecialAbility> spas) {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -825,7 +825,8 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
 
     private void addGroup(IOptionGroup group, GridBagLayout gridbag,
             GridBagConstraints c) {
-        JLabel groupLabel = new JLabel(group.getDisplayableName());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CustomizePersonDialog", new EncodeControl()); //$NON-NLS-1$
+        JLabel groupLabel = new JLabel(resourceMap.getString("optionGroup." + group.getKey())); //$NON-NLS-1$
 
         gridbag.setConstraints(groupLabel, c);
         panOptions.add(groupLabel);

--- a/MekHQ/src/mekhq/resources/CustomizePersonDialog.properties
+++ b/MekHQ/src/mekhq/resources/CustomizePersonDialog.properties
@@ -21,3 +21,6 @@ scrOptions.TabConstraints.tabTitle=Abilities
 lblLevel.text=Level:
 lblBonus.text=Bonus:
 age= years old
+optionGroup.lvl3Advantages=Advantages
+optionGroup.edgeAdvantages=Edge
+optionGroup.MDAdvantages=Warrior Augmentations


### PR DESCRIPTION
Access for SPA names and descriptions in PersonnelOptions. Checks SpecialAbility first and if not found, gets the value from MM PilotOptions. 
I also added names and descriptions for edge triggers to data/universe/defaultspa.xml. Feel free to modify, of course.